### PR TITLE
Don't match words containing "just"

### DIFF
--- a/plugin/words-to-avoid.vim
+++ b/plugin/words-to-avoid.vim
@@ -1,6 +1,6 @@
 function MatchTechWordsToAvoid()
   highlight TechWordsToAvoid ctermbg=red ctermfg=white guibg=red guifg=white
-  match TechWordsToAvoid /\c\<\(obviously\|basically\|simply\|of\scourse\|clearly\|\(\W\)\@<=just\(\W\)\@=\(\W\)\@<!\|everyone\sknows\|however\|so,\|easy\)\>/
+  match TechWordsToAvoid /\c\<\(obviously\|basically\|simply\|of\scourse\|clearly\|\(^\|\W\)\@<=just\(\W\)\@=\(\W\)\@<!\|everyone\sknows\|however\|so,\|easy\)\>/
 endfunction
 
 autocmd FileType markdown call MatchTechWordsToAvoid()


### PR DESCRIPTION
Only match the word "just" when preceded and followed by a non-word character. This prevents matches of words like "justified" or "adjust".
