### PR TITLE
Use function! to avoid errors on re-sourcing

### DIFF
--- a/plugin/words-to-avoid.vim
+++ b/plugin/words-to-avoid.vim
@@ -1,4 +1,4 @@
-function MatchTechWordsToAvoid()
+function! MatchTechWordsToAvoid()
   highlight TechWordsToAvoid ctermbg=red ctermfg=white guibg=red guifg=white
   match TechWordsToAvoid /\c\<\(obviously\|basically\|simply\|of\scourse\|clearly\|\(^\|\W\)\@<=just\(\W\)\@=\(\W\)\@<!\|everyone\sknows\|however\|so,\|easy\)\>/
 endfunction


### PR DESCRIPTION
Using `function` (instead of `function!`) makes Vim show an error message if
vimrc is re-sourced.
